### PR TITLE
Support Elixir 1.14, change :download_data_on_compile default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
               otp: "24.3.4.10"
           - pair:
               elixir: "1.18.3"
-              otp: "27.3"
+              otp: "27.3.3"
     env:
       MIX_ENV: test
     steps:

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 import Config
 
-config :public_sufx, download_data_on_compile: true
+config :public_sufx, download_data_on_compile: false
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule PublicSufx.Mixfile do
     [
       app: :public_sufx,
       version: @version,
-      elixir: "~> 1.15",
+      elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       description: description(),
       package: package(),


### PR DESCRIPTION
This is to be able to support Elixir 1.14 in http_cookie, as per [user request](https://github.com/reisub/http_cookie/issues/4).